### PR TITLE
grouper: Fix pinmux init race condition

### DIFF
--- a/arch/arm/mach-tegra/board-grouper.c
+++ b/arch/arm/mach-tegra/board-grouper.c
@@ -1016,7 +1016,6 @@ static void __init tegra_grouper_init(void)
 				throttle_list,
 				ARRAY_SIZE(throttle_list));
 	tegra_clk_init_from_table(grouper_clk_init_table);
-	grouper_pinmux_init();
 	grouper_misc_reset();
 	grouper_booting_info();
 	grouper_i2c_init();
@@ -1070,11 +1069,17 @@ static void __init tegra_grouper_reserve(void)
 	grouper_ramconsole_reserve(SZ_1M);
 }
 
+static void __init tegra_grouper_init_early(void)
+{
+	tegra_init_early();
+	grouper_pinmux_init();
+}
+
 MACHINE_START(GROUPER, "grouper")
 	.boot_params	= 0x80000100,
 	.map_io		= tegra_map_common_io,
 	.reserve	= tegra_grouper_reserve,
-	.init_early	= tegra_init_early,
+	.init_early	= tegra_grouper_init_early,
 	.init_irq	= tegra_init_irq,
 	.timer		= &tegra_timer,
 	.init_machine	= tegra_grouper_init,


### PR DESCRIPTION
Pinmux init does not complete early enough on some devices, causing the device to not boot.

Signed-off-by: Sultanxda <sultanxda@gmail.com>