### PR TITLE
arm: tegra: la: Fix id_to_index array initialization

### DIFF
--- a/arch/arm/mach-tegra/latency_allowance.c
+++ b/arch/arm/mach-tegra/latency_allowance.c
@@ -15,6 +15,7 @@
  */
 
 #include <linux/types.h>
+#include <linux/delay.h>
 #include <linux/init.h>
 #include <linux/kernel.h>
 #include <linux/debugfs.h>
@@ -337,8 +338,10 @@ static int __init tegra_latency_allowance_init(void)
 	la_scaling_enable_count = 0;
 	memset(&id_to_index[0], 0xFF, sizeof(id_to_index));
 
-	for (i = 0; i < ARRAY_SIZE(la_info_array); i++)
+	for (i = 0; i < ARRAY_SIZE(la_info_array); i++) {
 		id_to_index[la_info_array[i].id] = i;
+		usleep_range(1, 1);
+	}
 
 	tegra_set_latency_allowance(TEGRA_LA_G2PR, 20);
 	tegra_set_latency_allowance(TEGRA_LA_G2SR, 20);


### PR DESCRIPTION
id_to_index[] is not initialized properly, causing all of its contents to be stuck at 0xFFFF. As a result, when drivers try to set a latency allowance, it fails with:
[   13.270944] tegra_set_latency_allowance: invalid Id=4

Sleep for 1 usec after each iteration when id_to_index[] is initialized to ensure that it is initialized properly with all of the client IDs.

Signed-off-by: Sultanxda <sultanxda@gmail.com>